### PR TITLE
Fixed transposition in first line of readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-Sorlita.js
+Solrita.js
 ==========
 
 A Backbone.js client for Apache Solr. 


### PR DESCRIPTION
Thanks to the torturous spelling of "Solr" there's bound to be a few typos of it in the docs.  It's just sheer bad luck that there was one was in the first line :)
